### PR TITLE
Keep `spec/db` to avoid errors when running `crystal spec`

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -44,7 +44,6 @@ jobs:
         run: sqlite3 --version
       - name: Create Sqlite databases
         run: |
-          mkdir -p ./spec/db
           touch ./spec/db/northwind.db
           touch ./spec/db/data.db
           touch ./spec/db/billing.db


### PR DESCRIPTION
This is what I get otherwise:

```
Unhandled exception:  (DB::ConnectionRefused)
  from lib/sqlite3/src/sqlite3/connection.cr:55:5 in 'initialize'
  from lib/sqlite3/src/sqlite3/connection.cr:45:3 in 'new'
  from lib/sqlite3/src/sqlite3/driver.cr:7:7 in 'build'
  from lib/db/src/db.cr:173:5 in 'build_connection'
  from lib/db/src/db.cr:169:5 in 'build_connection'
  from lib/db/src/db.cr:141:5 in 'connect'
  from src/schema.cr:89:13 in 'initialize'
  from src/schema.cr:88:5 in 'new'
  from src/schema.cr:72:7 in '~Billing:const_init'
  from spec/schemas/data.cr:1:1 in '__crystal_main'
  from /usr/lib/crystal/crystal/main.cr:118:5 in 'main_user_code'
  from /usr/lib/crystal/crystal/main.cr:104:7 in 'main'
  from /usr/lib/crystal/crystal/main.cr:130:3 in 'main'
  from /usr/lib/libc.so.6 in '??'
  from /usr/lib/libc.so.6 in '__libc_start_main'
  from /home/snacks/.cache/crystal/crystal-run-spec.tmp in '_start'
  from ???
```
