### PR TITLE
Add support for array values in WHERE clause of CQL queries

### DIFF
--- a/spec/core/query_spec.cr
+++ b/spec/core/query_spec.cr
@@ -142,6 +142,34 @@ describe CQL::Query do
 
       select_query.should eq({output.strip, [1000]})
     end
+
+    it "handles array values in WHERE clause" do
+      select_query = Northwind.query
+        .from(:customers)
+        .select(:name, :city)
+        .where(id: [1, 2, 3])
+        .to_sql
+
+      output = <<-SQL
+        SELECT customers.name, customers.city FROM customers WHERE customers.id IN (?, ?, ?)
+      SQL
+
+      select_query.should eq({output.strip, [1, 2, 3]})
+    end
+
+    it "handles multiple array conditions in WHERE clause" do
+      select_query = Northwind.query
+        .from(:customers)
+        .select(:name, :city)
+        .where(id: [1, 2, 3], city: ["Rome", "Vienna"])
+        .to_sql
+
+      output = <<-SQL
+        SELECT customers.name, customers.city FROM customers WHERE (customers.id IN (?, ?, ?)) AND (customers.city IN (?, ?))
+      SQL
+
+      select_query.should eq({output.strip, [1, 2, 3, "Rome", "Vienna"]})
+    end
   end
 
   describe "ORDER BY, LIMIT, and other clauses" do

--- a/src/column.cr
+++ b/src/column.cr
@@ -1,3 +1,7 @@
+require "./base_column"
+require "db"
+require "./table"
+
 module CQL
   # A column in a table
   # This class represents a column in a table
@@ -19,7 +23,7 @@ module CQL
     # :nodoc:
     property name : Symbol
     # :nodoc:
-    property type : Any
+    property type : T.class | Array(T.class)
     # :nodoc:
     getter? null : Bool = false
     # :nodoc:
@@ -55,7 +59,7 @@ module CQL
     # ```
     def initialize(
       @name : Symbol,
-      @type : T.class,
+      @type : T.class | Array(T.class),
       @as_name : String? = nil,
       @null : Bool = false,
       @default : DB::Any = nil,
@@ -88,10 +92,10 @@ module CQL
     # column = CQL::Column.new(:name, String)
     # column.validate!("John")
     # ```
-    def validate!(value)
-      return if value.class == JSON::Any && value.is_a?(String)
-      return if value.class == type
-      raise Error.new "Expected column `#{name}` to be #{type}, but got #{value.class}"
+    def validate!(value : T | Array(T)) forall T
+      return if value.class == JSON::Any
+      return if value.class == T
+      raise Error.new "Expected column `#{name}` to be #{type} or Array(#{type}), but got #{value.class}"
     end
   end
 end

--- a/src/expression/expressions.cr
+++ b/src/expression/expressions.cr
@@ -326,7 +326,7 @@ module Expression
     getter column : Column
     getter values : Array(DB::Any)
 
-    def initialize(@column : Column, values : Array(T)) forall T
+    def initialize(@column : Column, values)
       @values = values.map { |v| v.as(DB::Any) }
     end
 

--- a/src/query.cr
+++ b/src/query.cr
@@ -437,10 +437,9 @@ module CQL
     end
 
     # Accept Hash(Symbol, DB::Any) for backward compatibility
-    def where(hash : Hash(String | Symbol, DB::Any))
+    def where(hash : Hash(String | Symbol, DB::Any | Array(DB::Any)))
       # Convert Symbol keys to String
-      string_keyed_hash = hash.transform_keys(&.to_s)
-      new_condition = build_condition_from_hash(string_keyed_hash)
+      new_condition = build_condition_from_hash(hash)
       merge_where_condition(new_condition)
       self
     end
@@ -458,7 +457,7 @@ module CQL
     end
 
     def where(**fields)
-      new_condition = build_condition_from_hash(fields.to_h)
+      new_condition = build_condition_from_hash(fields)
       merge_where_condition(new_condition)
       self
     end
@@ -726,12 +725,24 @@ module CQL
     end
 
     # Expects hash with String keys now
-    private def build_condition_from_hash(hash : Hash(Symbol | String, DB::Any))
+    private def build_condition_from_hash(hash : Hash(Symbol | String, T | Array(T))) forall T
       condition = nil
       hash.each_with_index do |(k, v), index|
         # k is String (qualified or unqualified column name)
+        expr = get_expression(k, v.as(T)) # Handles String key
+        condition = index == 0 ? expr : Expression::And.new(condition.not_nil!, expr)
+      end
+      condition.not_nil!
+    end
+
+    private def build_condition_from_hash(fields)
+      condition = nil
+      index = 0
+      fields.each do |k, v|
+        # k is String (qualified or unqualified column name)
         expr = get_expression(k, v) # Handles String key
         condition = index == 0 ? expr : Expression::And.new(condition.not_nil!, expr)
+        index += 1
       end
       condition.not_nil!
     end
@@ -746,14 +757,40 @@ module CQL
     end
 
     # Handles String field (qualified or unqualified)
-    private def get_expression(field : Symbol | String, value)
+    private def get_expression(field : Symbol | String, value : T | Array(T)) forall T
+      # find_column handles String field, finds BaseColumn
+      column = find_column(field)
+      # find_alias_for_table returns String alias
+      col_alias_str = find_alias_for_table(column.table.not_nil!)
+      column.validate!(value.as(T))
+
+      # Create Expression::Column with String alias
+      col_expr = Expression::Column.new(column, alias_name: col_alias_str)
+
+      # Handle array values for IN conditions
+      if value.is_a?(Array)
+        Expression::InCondition.new(col_expr, value)
+      else
+        Expression::Compare.new(col_expr, "=", value.as(DB::Any))
+      end
+    end
+
+    private def get_expression(field : Symbol | String, value : String | Array(String))
       # find_column handles String field, finds BaseColumn
       column = find_column(field)
       # find_alias_for_table returns String alias
       col_alias_str = find_alias_for_table(column.table.not_nil!)
       column.validate!(value)
+
       # Create Expression::Column with String alias
-      Expression::Compare.new(Expression::Column.new(column, alias_name: col_alias_str), "=", value)
+      col_expr = Expression::Column.new(column, alias_name: col_alias_str)
+
+      # Handle array values for IN conditions
+      if value.is_a?(Array)
+        Expression::InCondition.new(col_expr, value)
+      else
+        Expression::Compare.new(col_expr, "=", value.as(DB::Any))
+      end
     end
 
     private def build_group_by


### PR DESCRIPTION
This pull request introduces support for handling array values in SQL `WHERE` clauses, improves type handling in the `CQL` module, and enhances query-building functionality. The changes include updates to allow arrays in conditions, adjustments to type definitions, and modifications to validation and query-building logic.

### Support for array values in `WHERE` clauses:
* Added test cases to validate handling of array values in `WHERE` clauses, including single and multiple array conditions (`spec/core/query_spec.cr`).
* Updated the `where` method to accept `Hash` values containing arrays, enabling more flexible query conditions (`src/query.cr`).

### Type handling improvements:
* Modified the `type` property in `CQL::Column` to support single types and arrays of types (`src/column.cr`).
* Updated the `validate!` method in `CQL::Column` to handle both single values and arrays, ensuring proper validation for array-based conditions (`src/column.cr`).

### Query-building enhancements:
* Enhanced the `build_condition_from_hash` and `get_expression` methods to handle array values, enabling the generation of `IN` conditions in SQL queries (`src/query.cr`). [[1]](diffhunk://#diff-083e4058b3cec3e7157f299c79dab6a32b20e59897772587f2f1f59aa1f51433L729-R745) [[2]](diffhunk://#diff-083e4058b3cec3e7157f299c79dab6a32b20e59897772587f2f1f59aa1f51433L749-R793)
* Simplified the `build_condition_from_hash` method by removing redundant logic and ensuring compatibility with array-based conditions (`src/query.cr`).